### PR TITLE
Create Asset objects in initializations

### DIFF
--- a/biztax/corporation.py
+++ b/biztax/corporation.py
@@ -26,6 +26,8 @@ class Corporation():
         # Create Asset object and calculate
         self.asset = Asset(self.btax_params, corp=True, data=self.data)
         self.asset.calc_all()
+        # Create earnings forecast
+        self.create_earnings()
     
     def create_debt(self):
         """
@@ -84,7 +86,6 @@ class Corporation():
         """
         Runs the static calculations.
         """
-        self.create_earnings()
         self.create_debt()
         self.file_taxes()
         self.real_activity()

--- a/biztax/corporation.py
+++ b/biztax/corporation.py
@@ -23,11 +23,7 @@ class Corporation():
             raise ValueError('btax_params must be DataFrame')
         # Create Data object
         self.data = Data()
-    
-    def create_asset(self):
-        """
-        Creates the Asset object for the Corporation.
-        """
+        # Create Asset object and calculate
         self.asset = Asset(self.btax_params, corp=True, data=self.data)
         self.asset.calc_all()
     
@@ -88,7 +84,6 @@ class Corporation():
         """
         Runs the static calculations.
         """
-        self.create_asset()
         self.create_earnings()
         self.create_debt()
         self.file_taxes()

--- a/biztax/passthrough.py
+++ b/biztax/passthrough.py
@@ -46,6 +46,8 @@ class PassThrough():
         # Create Asset object and calculate
         self.asset = Asset(self.btax_params, corp=False, data=self.data)
         self.asset.calc_all()
+        # Create earnings forecast
+        self.create_earnings()
     
     def create_earnings(self):
         """
@@ -193,7 +195,6 @@ class PassThrough():
         """
         Runs the static calculations
         """
-        self.create_earnings()
         self.create_debt()
         self.real_activity()
         self.calc_netinc()

--- a/biztax/passthrough.py
+++ b/biztax/passthrough.py
@@ -43,11 +43,7 @@ class PassThrough():
             raise ValueError('btax_params must be DataFrame')
         # Create Data object
         self.data = Data()
-    
-    def create_asset(self):
-        """
-        Creates the Asset object for the pass-through sector.
-        """
+        # Create Asset object and calculate
         self.asset = Asset(self.btax_params, corp=False, data=self.data)
         self.asset.calc_all()
     
@@ -197,7 +193,6 @@ class PassThrough():
         """
         Runs the static calculations
         """
-        self.create_asset()
         self.create_earnings()
         self.create_debt()
         self.real_activity()


### PR DESCRIPTION
This PR modifies the `Corporation` and `PassThrough` objects to create their associated `Asset` objects in the `__init__`  functions instead of when `calc_static()` is called. This should allow one to directly call `BusinessModel.update_elasticities()` and `BusinessModel.calc_withresponse()` without first calling `BusinessModel.calc_noresponse()`. 

This change shift some of the computations from the `calc_static` stage to the initializations. 

@martinholmer, is this what you have in mind to resolve the last comments of #61?