### PR TITLE
Fix bug in reform1 specification

### DIFF
--- a/biztax/tests/conftest.py
+++ b/biztax/tests/conftest.py
@@ -57,7 +57,7 @@ def reforms():
             'depr_15yr_bonus': 0.6,
             'depr_20yr_method': 'ADS',
             'depr_20yr_bonus': 0.4,
-            'depr_25yr_method': 'EconomicDS',
+            'depr_25yr_method': 'Economic',
             'depr_25yr_bonus': 0.2,
             'depr_275yr_method': 'GDS',
             'depr_275yr_bonus': 0.2,


### PR DESCRIPTION
This pull request fixes an incorrect depreciation method specified in test reform1.  This change was indicated by @codykallen in [this comment](https://github.com/PSLmodels/Business-Taxation/pull/74#issuecomment-475906035).

@codykallen, is it your expectation that changing this causes no difference in the test results?  Why would `GDS` and `Economic` depreciation methods produce exactly the same results?