### PR TITLE
Revise test reform1 to avoid use of an invalid depreciation method

### DIFF
--- a/biztax/tests/conftest.py
+++ b/biztax/tests/conftest.py
@@ -57,7 +57,7 @@ def reforms():
             'depr_15yr_bonus': 0.6,
             'depr_20yr_method': 'ADS',
             'depr_20yr_bonus': 0.4,
-            'depr_25yr_method': 'EconomicDS',
+            'depr_25yr_method': 'GDS',  # formerly specified as 'EconomicDS'
             'depr_25yr_bonus': 0.2,
             'depr_275yr_method': 'GDS',
             'depr_275yr_bonus': 0.2,


### PR DESCRIPTION
This pull request revises the specification of test reform 1 in a way that avoids the use of an invalid depreciation method.  This change has no effect on the test results or on the results generated by `example.py`.  This change implements @codykallen's recommendation in [this comment](https://github.com/PSLmodels/Business-Taxation/pull/75#issuecomment-475965468).