### PR TITLE
Add and use named constants instead of the "magic numbers" in the code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,14 +43,15 @@ pytest:
 
 .PHONY=pytest-all
 pytest-all:
-	@cd biztax ; pytest -n4 -m ""
+	@cd biztax ; pytest -n4
 	@$(pytest-cleanup)
 
 JSON_FILES := $(shell find . -name "*json" | grep -v htmlcov)
 
 .PHONY=cstest
 cstest:
-	@-pycodestyle biztax
+	@-pycodestyle --ignore=E501 biztax
+	@-pycodestyle --ignore=E501 biztax/tests
 	@-pycodestyle --ignore=E501,E121  $(JSON_FILES)
 
 define coverage-cleanup

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,7 @@ JSON_FILES := $(shell find . -name "*json" | grep -v htmlcov)
 
 .PHONY=cstest
 cstest:
-	@-pycodestyle --ignore=E501 biztax
-	@-pycodestyle --ignore=E501 biztax/tests
+	@-pycodestyle biztax
 	@-pycodestyle --ignore=E501,E121  $(JSON_FILES)
 
 define coverage-cleanup

--- a/biztax/__init__.py
+++ b/biztax/__init__.py
@@ -1,6 +1,7 @@
 """
 Specify what is available to import from the biztax package.
 """
+from biztax.years import START_YEAR, END_YEAR, NUM_YEARS
 from biztax.asset import Asset
 from biztax.btaxmini import BtaxMini
 from biztax.data import Data

--- a/biztax/businessmodel.py
+++ b/biztax/businessmodel.py
@@ -66,7 +66,7 @@ class BusinessModel():
         paramnames.remove('year')
         for key in paramdict:
             key2 = int(key)
-            assert key2 in range(2014, 2027)
+            assert key2 in range(START_YEAR, END_YEAR)
             for param in paramdict[key]:
                 assert param in paramnames
 
@@ -74,7 +74,7 @@ class BusinessModel():
         """
         Updates btax_params
         param_dict is a year: {param: value} dictionary.
-        Acceptable years are 2017-2027. Ex:
+        Acceptable years are 2017-END_YEAR. Ex:
             {'2018': {'tau_c': 0.3}}
         """
         self.check_btax_reform(param_dict)
@@ -133,7 +133,7 @@ class BusinessModel():
         # Calculate multiplier for equity income
         equity_multiplier = netinc_corp_ref / netinc_corp_base
         # Save into DataFrame
-        multipliers = pd.DataFrame({'year': range(2014, 2028),
+        multipliers = pd.DataFrame({'year': range(START_YEAR, END_YEAR + 1),
                                     'equity': equity_multiplier})
         # Get net income results for the pass-throughs
         netinc_ptbase = copy.deepcopy(self.passthru_base.netinc_results)
@@ -165,7 +165,8 @@ class BusinessModel():
         indivrev_ref = self.investor_ref.get_revenue_withdistribution()
         indivrev_change = indivrev_ref - indivrev_base
         alltax_change = corprev_change + indivrev_change
-        self.ModelResults = pd.DataFrame({'year': range(2014, 2028),
+        self.ModelResults = pd.DataFrame({'year': range(START_YEAR,
+                                                        END_YEAR + 1),
                                           'CTax_change': corprev_change,
                                           'ITax_change': indivrev_change,
                                           'AllTax_change': alltax_change})

--- a/biztax/businessmodel.py
+++ b/biztax/businessmodel.py
@@ -1,6 +1,7 @@
 import copy
 import numpy as np
 import pandas as pd
+from biztax.years import START_YEAR, END_YEAR, NUM_YEARS
 from biztax.data import Data
 from biztax.corporation import Corporation
 from biztax.passthrough import PassThrough

--- a/biztax/corporation.py
+++ b/biztax/corporation.py
@@ -11,11 +11,11 @@ from biztax.response import Response
 
 class Corporation():
     """
-    Constructor for the Corporation class. 
-    This contains both the real and tax information relevant to the 
+    Constructor for the Corporation class.
+    This contains both the real and tax information relevant to the
     corporate income tax.
     """
-    
+
     def __init__(self, btax_params):
         # Store policy parameter objects
         if isinstance(btax_params, pd.DataFrame):
@@ -29,25 +29,26 @@ class Corporation():
         self.asset.calc_all()
         # Create earnings forecast
         self.create_earnings()
-    
+
     def create_debt(self):
         """
-        Creates the Debt object for the Corporation. 
+        Creates the Debt object for the Corporation.
         Note: create_asset must have already been called
         """
         self.debt = Debt(self.btax_params, self.asset.get_forecast(),
                          data=self.data, corp=True)
         self.debt.calc_all()
-    
+
     def create_earnings(self):
         """
         Creates the initial forecast for earnings. Static only.
         """
         earnings_forecast = np.asarray(self.data.gfactors['profit'])
         earnings2013 = np.asarray(self.data.historical_taxdata['ebitda13'])[-1]
-        earnings_new = earnings_forecast[1:] / earnings_forecast[0] * earnings2013
+        earnings_new = (earnings_forecast[1:] / earnings_forecast[0]
+                        * earnings2013)
         self.earnings = earnings_new
-    
+
     def file_taxes(self):
         """
         Creates the CorpTaxReturn object.
@@ -56,7 +57,7 @@ class Corporation():
                                        data=self.data, assets=self.asset,
                                        debts=self.debt)
         self.taxreturn.calc_all()
-    
+
     def real_activity(self):
         """
         Produces a DataFrame of the corporation's real activity.
@@ -71,7 +72,7 @@ class Corporation():
             Net income
             Cash flow
         """
-        real_results = pd.DataFrame({'year': range(2014,2028),
+        real_results = pd.DataFrame({'year': range(START_YEAR, END_YEAR + 1),
                                      'Earnings': self.earnings})
         real_results['Kstock'] = self.asset.get_forecast()
         real_results['Inv'] = self.asset.get_investment()
@@ -79,10 +80,15 @@ class Corporation():
         real_results['Debt'] = self.debt.get_debt()
         real_results['NIP'] = self.debt.get_nip()
         real_results['Tax'] = self.taxreturn.get_tax()
-        real_results['NetInc'] = real_results['Earnings'] - real_results['Depr'] - real_results['NIP'] - real_results['Tax']
-        real_results['CashFlow'] = real_results['Earnings'] - real_results['Inv'] - real_results['Tax']
+        real_results['NetInc'] = (real_results['Earnings']
+                                  - real_results['Depr']
+                                  - real_results['NIP']
+                                  - real_results['Tax'])
+        real_results['CashFlow'] = (real_results['Earnings']
+                                    - real_results['Inv']
+                                    - real_results['Tax'])
         self.real_results = real_results
-    
+
     def calc_static(self):
         """
         Runs the static calculations.
@@ -90,15 +96,17 @@ class Corporation():
         self.create_debt()
         self.file_taxes()
         self.real_activity()
-    
+
     def update_legal(self, responses):
         """
         Updates the rescale_corp and rescale_noncorp associated with each
         Data associated with each object.
         """
-        self.data.update_rescaling(responses.rescale_corp, responses.rescale_noncorp)
-        self.asset.data.update_rescaling(responses.rescale_corp, responses.rescale_noncorp)
-    
+        self.data.update_rescaling(responses.rescale_corp,
+                                   responses.rescale_noncorp)
+        self.asset.data.update_rescaling(responses.rescale_corp,
+                                         responses.rescale_noncorp)
+
     def update_investment(self, responses):
         """
         Updates the Asset object to include investment response.
@@ -107,7 +115,7 @@ class Corporation():
         self.old_capital_history = copy.deepcopy(self.asset.capital_history)
         self.asset.update_response(responses.investment_response)
         self.asset.calc_all()
-    
+
     def update_earnings(self, responses):
         """
         Recalculates earnings using the old capital stock by asset type, the
@@ -117,16 +125,18 @@ class Corporation():
         Kstock_base = copy.deepcopy(self.old_capital_history)
         Kstock_ref = copy.deepcopy(self.asset.capital_history)
         deltaK = Kstock_ref - Kstock_base
-        changeEarnings = np.zeros((96, 14))
-        for j in range(14): # for each year
-            mpk = np.array(responses.investment_response['MPKc' + str(j + 2014)])
-            for i in range(96): # by asset
-                changeEarnings[i,j] = deltaK[i,j] * mpk[i] * self.data.adjfactor_dep_corp
-        deltaE = np.zeros(14)
-        for j in range(14):
-            deltaE[j] = changeEarnings[:, j].sum()
+        changeEarnings = np.zeros((96, NUM_YEARS))
+        for iyr in range(NUM_YEARS):  # for each year
+            ystr = str(iyr + START_YEAR)
+            mpk = np.array(responses.investment_response['MPKc' + ystr])
+            for i in range(96):  # by asset
+                changeEarnings[i, iyr] = (deltaK[i, iyr] * mpk[i]
+                                          * self.data.adjfactor_dep_corp)
+        deltaE = np.zeros(NUM_YEARS)
+        for iyr in range(NUM_YEARS):
+            deltaE[iyr] = changeEarnings[:, iyr].sum()
         self.earnings = (self.earnings + deltaE) * self.data.rescale_corp
-    
+
     def update_debt(self, responses):
         """
         Replaces the Debt object to use the new asset forecast and Data
@@ -135,10 +145,10 @@ class Corporation():
         self.debt = Debt(self.btax_params, self.asset.get_forecast(),
                          data=self.data, response=pctch_delta, corp=True)
         self.debt.calc_all()
-    
+
     def apply_responses(self, responses):
         """
-        Updates Data, Asset, earnings, Debt and CorpTaxReturn to include 
+        Updates Data, Asset, earnings, Debt and CorpTaxReturn to include
         responses. Then calc_all() for each object.
         """
         assert isinstance(responses, Response)
@@ -148,19 +158,17 @@ class Corporation():
         self.update_debt(responses)
         self.file_taxes()
         self.real_activity()
-        
+
     def get_netinc(self):
         """
         Returns an array of the corporation's net income (after-tax).
         """
         netinc = np.array(self.real_results['NetInc'])
         return netinc
-    
+
     def get_taxrev(self):
         """
         Returns an array of the corporation's tax liability.
         """
         taxrev = np.array(self.real_results['Tax'])
         return taxrev
-    
-        

--- a/biztax/corporation.py
+++ b/biztax/corporation.py
@@ -1,6 +1,7 @@
+import copy
 import numpy as np
 import pandas as pd
-import copy
+from biztax.years import START_YEAR, END_YEAR, NUM_YEARS
 from biztax.data import Data
 from biztax.asset import Asset
 from biztax.debt import Debt

--- a/biztax/corptaxreturn.py
+++ b/biztax/corptaxreturn.py
@@ -9,20 +9,20 @@ from biztax.debt import Debt
 
 class CorpTaxReturn():
     """
-    Constructor for the CorpTaxReturn object. 
-    This class includes objects relevant to the calculation of 
+    Constructor for the CorpTaxReturn object.
+    This class includes objects relevant to the calculation of
     corporate income tax liability:
         assets: an associated Asset object
         debts: an associated debt object
         combined_return: a DataFrame with tax calculations for each year
-    
+
     Parameters:
         btax_params: dict of business tax policy parameters
         assets: Asset object for the corporation
         debts: Debt object for the corporation
         earnings: list or array of earnings for each year in the budget window
     """
-    
+
     def __init__(self, btax_params, earnings,
                  data=None, assets=None, debts=None):
         # Create an associated Data object
@@ -52,13 +52,14 @@ class CorpTaxReturn():
             self.debts = Debt(btax_params, assets_forecast)
             self.debts.calc_all()
         # Use earnings to create DataFrame for results
-        assert len(earnings) == 14
-        combined = pd.DataFrame({'year': range(2014,2028), 'ebitda': earnings})
+        assert len(earnings) == NUM_YEARS
+        combined = pd.DataFrame({'year': range(START_YEAR, END_YEAR + 1),
+                                 'ebitda': earnings})
         # Add tax depreciation and net interest deductions
         combined['taxDep'] = self.assets.get_taxdep()
         combined['nid'] = self.debts.get_nid()
         self.combined_return = combined
-    
+
     def update_assets(self, assets):
         """
         Updates the Asset object associated with the tax return.
@@ -67,7 +68,7 @@ class CorpTaxReturn():
             self.assets = assets
         else:
             raise ValueError('assets must be Asset object')
-    
+
     def update_debts(self, debts):
         """
         Updates the Debt object associated with the tax return.
@@ -76,14 +77,14 @@ class CorpTaxReturn():
             self.debts = debts
         else:
             raise ValueError('debts must be Debt object')
-    
+
     def update_earnings(self, earnings):
         """
         Updates the earnings DataFrame associated with the tax return.
         """
-        assert len(earnings) == 14
+        assert len(earnings) == NUM_YEARS
         self.combined_return['ebitda'] = earnings
-    
+
     def calcSec199(self):
         """
         Calculates section 199 deduction.
@@ -91,12 +92,13 @@ class CorpTaxReturn():
         # Extract relevant parmeters
         s199_hclist = np.array(self.btax_params['sec199_hc'])
         profit = np.asarray(self.data.gfactors['profit_d'])
-        sec199_res = np.zeros(14)
+        sec199_res = np.zeros(NUM_YEARS)
         sec199_2013 = np.asarray(self.data.historical_taxdata['sec199'])[-1]
-        for i in range(14):
-            sec199_res[i] = profit[i+1] / profit[0] * sec199_2013 * (1 - s199_hclist[i])
+        for iyr in range(NUM_YEARS):
+            sec199_res[iyr] = (profit[iyr + 1] / profit[0] * sec199_2013
+                               * (1 - s199_hclist[iyr]))
         self.combined_return['sec199'] = sec199_res
-    
+
     def calcInitialTax(self):
         """
         Calculates taxable income and tax before credits.
@@ -108,12 +110,13 @@ class CorpTaxReturn():
         self.combined_return['tau'] = self.btax_params['tau_c']
         self.combined_return['taxbc'] = (self.combined_return['taxinc'] *
                                          self.combined_return['tau'])
-    
+
     def calcFTC(self):
         """
-        Calculates foreign tax credit for 2014-2027.
+        Calculates foreign tax credit for [START_YEAR, END_YEAR].
         """
         hclist = np.array(self.btax_params['ftc_hc'])
+
         def calcWAvgTaxRate(year):
             """
             Calculates the weighted average statutory corporate tax rate
@@ -128,20 +131,21 @@ class CorpTaxReturn():
             gdp_list2 = np.where(np.isnan(taxrate_list), 0, gdp_list)
             avgrate = sum(taxrate_list2 * gdp_list2) / sum(gdp_list2)
             return avgrate
+
         # Get foreign profits forecast
         profits = np.asarray(self.data.ftc_other_data['C_total'][19:])
         profits_d = np.asarray(self.data.ftc_other_data['C_domestic'][19:])
-        tax_f = np.zeros(14)
-        for i in range(14):
-            tax_f[i] = calcWAvgTaxRate(i + 2014)
+        tax_f = np.zeros(NUM_YEARS)
+        for iyr in range(NUM_YEARS):
+            tax_f[iyr] = calcWAvgTaxRate(iyr + START_YEAR)
         ftc_final = ((profits - profits_d) * tax_f / 100. *
                      self.data.adjfactor_ftc_corp *
                      (1 - hclist)) * self.data.rescale_corp
         self.combined_return['ftc'] = ftc_final
-    
+
     def calcAMT(self):
         """
-        Calculates the AMT revenue and PYMTC for 2014-2027
+        Calculates the AMT revenue and PYMTC for [START_YEAR, END_YEAR]
         pymtc_status: 0 for no change, 1 for repeal, 2 for refundable
         """
         # Get relevant tax information
@@ -153,10 +157,10 @@ class CorpTaxReturn():
         for x in pymtc_status:
             assert x in [0, 1, 2]
         # Create empty arrays for AMT, PYMTC, and stocks (by status)
-        A = np.zeros(14)
-        P = np.zeros(14)
-        stockA = np.zeros(15)
-        stockN = np.zeros(15)
+        A = np.zeros(NUM_YEARS)
+        P = np.zeros(NUM_YEARS)
+        stockA = np.zeros(NUM_YEARS + 1)
+        stockN = np.zeros(NUM_YEARS + 1)
         stockA[0] = ((self.data.trans_amt1 * self.data.userate_pymtc + self.data.trans_amt2 *
                       (1 - self.data.userate_pymtc)) / (1 - self.data.trans_amt1) * self.data.stock2014)
         stockN[0] = self.data.stock2014 - stockN[0]
@@ -164,45 +168,50 @@ class CorpTaxReturn():
                                                   self.data.userate_pymtc + self.data.trans_amt2 *
                                                   (1 - self.data.userate_pymtc)) * self.data.stock2014
         stockA[0] = self.data.stock2014 - stockN[0]
-        for i in range(14):
+        for iyr in range(NUM_YEARS):
             # Calculate AMT
-            if amt_rates[i] == 0.:
+            if amt_rates[iyr] == 0.:
                 # If no AMT
-                A[i] = 0.
+                A[iyr] = 0.
                 frac_amt = 0.
-            elif ctax_rates[i] <= amt_rates[i]:
+            elif ctax_rates[iyr] <= amt_rates[iyr]:
                 # If AMT rate exceeds regular rate (all subject to AMT)
-                A[i] = ((amt_rates[i] - ctax_rates[i] + amt_rates[i] / self.data.param_amt) *
-                        taxinc[i])
+                A[iyr] = ((amt_rates[iyr] - ctax_rates[iyr]
+                           + amt_rates[iyr] / self.data.param_amt)
+                          * taxinc[iyr])
                 frac_amt = 0.999
             else:
-                A[i] = (amt_rates[i] / self.data.param_amt *
-                        np.exp(-self.data.param_amt * (ctax_rates[i] / amt_rates[i] - 1)) *
-                        taxinc[i])
-                frac_amt = np.exp(-self.data.param_amt * (ctax_rates[i] / amt_rates[i] - 1))
+                A[iyr] = (amt_rates[iyr] / self.data.param_amt *
+                          np.exp(-self.data.param_amt
+                                 * (ctax_rates[iyr] / amt_rates[iyr] - 1))
+                          * taxinc[iyr])
+                frac_amt = np.exp(-self.data.param_amt
+                                  * (ctax_rates[iyr] / amt_rates[iyr] - 1))
             # Adjust transition params for change in AMT frequency
-            alpha = max(0.0, min(1.0, self.data.trans_amt1 * (frac_amt / self.data.amt_frac)**0.5))
+            alpha = max(0.0, min(1.0,
+                                 (self.data.trans_amt1
+                                  * (frac_amt / self.data.amt_frac) ** 0.5)))
             beta = (1 - alpha) * frac_amt / (1 - frac_amt)
-            if pymtc_status[i] == 0:
+            if pymtc_status[iyr] == 0:
                 # No change from baseline
                 userate = self.data.userate_pymtc
-            elif pymtc_status[i] == 1:
+            elif pymtc_status[iyr] == 1:
                 # PYMTC repealed
                 userate = 0.0
             else:
                 # PYMTC made fully refundable
                 userate = 1.0
-            P[i] = userate * stockN[i]
-            stockA[i+1] = (alpha * (stockA[i] + A[i]) +
-                           beta * (stockN[i] - P[i]))
-            stockN[i+1] = ((1 - alpha) * (stockA[i] + A[i]) +
-                           (1 - beta) * (stockN[i] - P[i]))
+            P[iyr] = userate * stockN[iyr]
+            stockA[iyr+1] = (alpha * (stockA[iyr] + A[iyr]) +
+                             beta * (stockN[iyr] - P[iyr]))
+            stockN[iyr+1] = ((1 - alpha) * (stockA[iyr] + A[iyr]) +
+                             (1 - beta) * (stockN[iyr] - P[iyr]))
         # Rescale for any cross-sector shifting
         amt_final = A * self.data.rescale_corp
         pymtc_final = P * self.data.rescale_corp
         self.combined_return['amt'] = amt_final
         self.combined_return['pymtc'] = pymtc_final
-    
+
     def calcTax(self):
         """
         Calculates final tax liability.
@@ -218,7 +227,7 @@ class CorpTaxReturn():
                                           self.combined_return['ftc'] -
                                           self.combined_return['pymtc'] -
                                           self.combined_return['gbc'])
-    
+
     def calc_all(self):
         """
         Executes all tax calculations.
@@ -228,20 +237,17 @@ class CorpTaxReturn():
         self.calcFTC()
         self.calcAMT()
         self.calcTax()
-    
+
     def getReturn(self):
         """
         Returns the tax return information
         """
         combined_result = copy.deepcopy(self.combined_return)
         return combined_result
-    
+
     def get_tax(self):
         """
         Returns the total tax liability.
         """
-        tax1 = np.array(self.combined_return['taxrev'])
-        return tax1
-    
-    
-    
+        tax = np.array(self.combined_return['taxrev'])
+        return tax

--- a/biztax/corptaxreturn.py
+++ b/biztax/corptaxreturn.py
@@ -1,6 +1,7 @@
+import copy
 import numpy as np
 import pandas as pd
-import copy
+from biztax.years import START_YEAR, END_YEAR, NUM_YEARS
 from biztax.data import Data
 from biztax.asset import Asset
 from biztax.debt import Debt

--- a/biztax/data.py
+++ b/biztax/data.py
@@ -2,6 +2,7 @@ import os
 import numpy as np
 import pandas as pd
 from taxcalc import read_egg_csv
+from biztax.years import START_YEAR, END_YEAR, NUM_YEARS
 
 
 CURRENT_PATH = os.path.abspath(os.path.dirname(__file__))

--- a/biztax/data.py
+++ b/biztax/data.py
@@ -81,8 +81,8 @@ class Data():
             os.path.join(CURRENT_PATH, 'mini_params_btax.csv'))
         self.econ_defaults = read_csv(
             os.path.join(CURRENT_PATH, 'mini_params_econ.csv'))
-        self.rescale_corp = np.ones(14)
-        self.rescale_noncorp = np.ones(14)
+        self.rescale_corp = np.ones(NUM_YEARS)
+        self.rescale_noncorp = np.ones(NUM_YEARS)
         # Read in adjustment factors
         adj_factors = read_csv('adjfactors.csv')
         self.param_amt = adj_factors['param_amt'].values[0]
@@ -162,7 +162,7 @@ class Data():
         """
         Updates the rescaling factors associated with the Data class object
         """
-        assert len(corparray) == 14
-        assert len(ncorparray) == 14
+        assert len(corparray) == NUM_YEARS
+        assert len(ncorparray) == NUM_YEARS
         self.rescale_corp = corparray
         self.rescale_noncorp = ncorparray

--- a/biztax/debt.py
+++ b/biztax/debt.py
@@ -1,6 +1,7 @@
+import copy
 import numpy as np
 import pandas as pd
-import copy
+from biztax.years import START_YEAR, END_YEAR, NUM_YEARS
 from biztax.data import Data
 
 class Debt():

--- a/biztax/debt.py
+++ b/biztax/debt.py
@@ -4,12 +4,13 @@ import pandas as pd
 from biztax.years import START_YEAR, END_YEAR, NUM_YEARS
 from biztax.data import Data
 
+
 class Debt():
     """
     Constructor for the Debt class.
     This class includes several objects related to debt:
         debt history:
-            record from 1960 - 2027 of debt-related measures:
+            record from 1960 - END_YEAR of debt-related measures:
                 K_fa: assets (financial accounts)
                 A: debt assets
                 L: debt liabilities
@@ -19,7 +20,7 @@ class Debt():
             debt_totals: aggregate debt amounts
             interest_real: interest received and paid
             interest_tax: taxable interest income and interest deductions
-    
+
     Parameters:
         corp: True for corporate, False for noncorporate
         btax_params: DataFrame of business tax policy parameters
@@ -27,9 +28,9 @@ class Debt():
         response: array of percent changes in optimal debt-asset ratios
         eta: debt retirement rate
     """
-    
+
     def __init__(self, btax_params, asset_forecast,
-                 data=None, response=None, eta = 0.4, corp=True):
+                 data=None, response=None, eta=0.4, corp=True):
         # Create an associated Data object
         if isinstance(data, Data):
             self.data = data
@@ -43,18 +44,20 @@ class Debt():
             self.btax_params = btax_params
         else:
             raise ValueError('btax_params must be DataFrame')
-        if response is not None:
-            if len(response) == 14:
+        if response is None:
+            self.response = np.zeros(NUM_YEARS)
+        else:
+            if len(response) == NUM_YEARS:
                 self.response = response
             else:
                 raise ValueError('Wrong response')
-        else:
-            self.response = np.zeros(14)
         if corp:
-            self.delta = np.array(self.data.econ_defaults['f_c']) * (1 + self.response)
+            self.delta = (np.array(self.data.econ_defaults['f_c'])
+                          * (1 + self.response))
         else:
-            self.delta = np.array(self.data.econ_defaults['f_nc']) * (1 + self.response)
-        if len(asset_forecast) == 14:
+            self.delta = (np.array(self.data.econ_defaults['f_nc'])
+                          * (1 + self.response))
+        if len(asset_forecast) == NUM_YEARS:
             self.asset_forecast = asset_forecast
         else:
             raise ValueError('Wrong length for asset forecast')
@@ -62,7 +65,7 @@ class Debt():
             self.eta = eta
         else:
             raise ValueError('Value of eta inappropriate')
-    
+
     def get_haircuts(self):
         if self.corp:
             hc_nids = np.array(self.btax_params['netIntPaid_corp_hc'])
@@ -71,22 +74,22 @@ class Debt():
             hc_id_new_years = np.array(self.btax_params['newIntPaid_corp_hcyear'])
             hc_id_news = np.array(self.btax_params['newIntPaid_corp_hc'])
         else:
-            hc_nids =np.zeros(14)
+            hc_nids = np.zeros(NUM_YEARS)
             hc_id_old_years = np.array(self.btax_params['oldIntPaid_noncorp_hcyear'])
             hc_id_olds = np.array(self.btax_params['oldIntPaid_noncorp_hc'])
             hc_id_new_years = np.array(self.btax_params['newIntPaid_noncorp_hcyear'])
             hc_id_news = np.array(self.btax_params['newIntPaid_noncorp_hc'])
         haircuts = {}
-        haircuts['nid_hc']= hc_nids
+        haircuts['nid_hc'] = hc_nids
         haircuts['id_hc_oldyear'] = hc_id_old_years
         haircuts['id_hc_old'] = hc_id_olds
         haircuts['id_hc_newyear'] = hc_id_new_years
         haircuts['id_hc_new'] = hc_id_news
         self.haircuts = haircuts
-    
+
     def build_level_history(self):
         """
-        Constructs the debt level history from 1960 to 2016. 
+        Constructs the debt level history from 1960 to 2016.
         """
         # Grab historical records for 1960-2016
         if self.corp:
@@ -108,7 +111,8 @@ class Debt():
             K_fa.append(K_fa[56] * self.asset_forecast[i-54] /
                         self.asset_forecast[2])
             A.append(A[56] * K_fa[i] / K_fa[56])
-            D.append(D[56] * K_fa[i] / K_fa[56] * self.delta[i-54] / self.delta[2])
+            D.append(D[56] * K_fa[i] / K_fa[56] *
+                     self.delta[i-54] / self.delta[2])
             L.append(D[i] + A[i])
         # Save level histories
         self.net_debt_history = D
@@ -116,22 +120,22 @@ class Debt():
         self.debt_liab_history = L
         self.i_a = [x / 100. for x in i_t]
         self.i_l = [(i_t[i] + i_pr[i]) / 100. for i in range(len(i_t))]
-    
+
     def build_flow_history(self):
         """
-        Constructs originations. 
+        Constructs originations.
         """
         O = np.zeros(68)
-        for i in range(1,68):
+        for i in range(1, 68):
             O[i] = (self.debt_liab_history[i] -
                     self.debt_liab_history[i-1] * (1 - self.eta))
         self.originations = O
-    
+
     def constrain_history(self):
         """
         Recalculates level and flow histories subject to the constraint that
-        originations must be nonnegative. 
-        
+        originations must be nonnegative.
+
         Note: This is not binding in general, only in the cases of either
               large changes to the optimal debt-to-asset ratio or for very low
               values of eta.
@@ -142,13 +146,13 @@ class Debt():
             L = np.zeros(68)
             L[0] = L_opt[0]
             O = np.zeros(68)
-            for i in range(1,68):
+            for i in range(1, 68):
                 O[i] = max(L_opt[i] - L[i-1] * (1 - self.eta), 0.)
                 L[i] = L[i-1] * (1 - self.eta) + O[i]
             self.debt_liab_history = L
             self.originations = O
             self.net_debt_history = L + A
-    
+
     def calc_real_interest(self):
         """
         Calculates interest income, interest paid and net interest paid.
@@ -160,7 +164,7 @@ class Debt():
                 int_expense[i] += (self.originations[j] *
                                    (1 - self.eta)**(i - j) * self.i_l[j])
         self.int_expense = int_expense
-    
+
     def calc_tax_interest(self):
         """
         Calculates taxable interest income, deductible interest and the
@@ -192,14 +196,14 @@ class Debt():
         NID = NID_gross * (1 - nid_hc)
         self.int_expded = int_expded
         self.NID = NID
-    
+
     def build_interest_path(self):
         """
         Builds a DataFrame wit relevant debt information for the budget window:
             debt: net debt totals
             nip: net interest paid
             nid: net interest deduction
-            
+
         WARNING: May need to include rescale_corp and rescale_noncorp
         """
         if self.corp:
@@ -207,12 +211,16 @@ class Debt():
         else:
             adjfactor = self.data.adjfactor_int_noncorp
         debt = np.array(self.net_debt_history[54:68]) * adjfactor
-        nip = np.array(self.int_expense[54:68] - self.int_income[54:68]) * adjfactor
-        nid = np.array(self.int_expded[54:68] - self.int_income[54:68]) * adjfactor
-        NID_results = pd.DataFrame({'year': range(2014, 2028), 'nid': nid,
-                                    'nip': nip, 'debt': debt})
+        nip = np.array(self.int_expense[54:68]
+                       - self.int_income[54:68]) * adjfactor
+        nid = np.array(self.int_expded[54:68]
+                       - self.int_income[54:68]) * adjfactor
+        NID_results = pd.DataFrame({'year': range(START_YEAR, END_YEAR + 1),
+                                    'nid': nid,
+                                    'nip': nip,
+                                    'debt': debt})
         self.interest_path = NID_results
-    
+
     def calc_all(self):
         """
         Executes all calculations for Debt object.
@@ -225,27 +233,24 @@ class Debt():
         self.calc_tax_interest()
         self.build_interest_path()
         return None
-    
+
     def get_nid(self):
         """
-        Returns the net interest deductions for 2014-2027
+        Returns the net interest deductions for [START_YEAR, END_YEAR]
         """
         nid = np.array(self.interest_path['nid'])
         return nid
-    
+
     def get_nip(self):
         """
-        Returns the net interest paid for 2014-2027
+        Returns the net interest paid for [START_YEAR, END_YEAR]
         """
         nip = np.array(self.interest_path['nip'])
         return nip
-    
+
     def get_debt(self):
         """
-        Returns the net debtfor 2014-2027
+        Returns the net debtfor [START_YEAR, END_YEAR]
         """
-        debt1 = np.array(self.interest_path['debt'])
-        return debt1
-    
-    
-    
+        debt = np.array(self.interest_path['debt'])
+        return debt

--- a/biztax/investor.py
+++ b/biztax/investor.py
@@ -1,7 +1,8 @@
+import copy
 import numpy as np
 import pandas as pd
-import copy
-from taxcalc import Policy, Records, Calculator
+import taxcalc as itax
+from biztax.years import START_YEAR, END_YEAR, NUM_YEARS
 from biztax.data import Data
 
 class Investor():
@@ -13,8 +14,8 @@ class Investor():
     and pass-through business net income.
     
     Parameters:
-        refdict: individual-income-tax reform dict for taxcalc.Policy class
-        data: investor data for taxcalc.Records class
+        refdict: individual-income-tax reform dict for itax.Policy class
+        data: investor data for itax.Records class
     """
     
     def __init__(self, refdict=None, data='puf.csv'):
@@ -38,13 +39,13 @@ class Investor():
         """
         Creates an intial version of the taxcalc.Calculator object for 2014
         """
-        policy1 = Policy()
-        records1 = Records(data=self.records_data)
+        policy = itax.Policy()
+        records = itax.Records(data=self.records_data)
         if self.refdict != {}:
-            policy1.implement_reform(self.refdict)
-        calc1 = Calculator(records=records1, policy=policy1, verbose=False)
-        calc1.advance_to_year(2014)
-        calc1.calc_all()
+            policy.implement_reform(self.refdict)
+        calc = itax.Calculator( policy=policy, records=records, verbose=False)
+        calc.advance_to_year(2014)
+        calc.calc_all()
         return(calc1)
     
     def calc_tauNC(self, mtrdict, incdict):

--- a/biztax/investor.py
+++ b/biztax/investor.py
@@ -46,7 +46,7 @@ class Investor():
         calc = itax.Calculator( policy=policy, records=records, verbose=False)
         calc.advance_to_year(2014)
         calc.calc_all()
-        return(calc1)
+        return calc
     
     def calc_tauNC(self, mtrdict, incdict):
         """

--- a/biztax/investor.py
+++ b/biztax/investor.py
@@ -1,3 +1,6 @@
+"""
+Business-Taxation Investor class.
+"""
 import copy
 import numpy as np
 import pandas as pd
@@ -5,23 +8,24 @@ import taxcalc as itax
 from biztax.years import START_YEAR, END_YEAR, NUM_YEARS
 from biztax.data import Data
 
+
 class Investor():
     """
     Constructor for the Investor class.
-    
-    This class provides information on effective marginal tax rates on 
+
+    This class provides information on effective marginal tax rates on
     investment income and distributes changes in corporate after-tax income
     and pass-through business net income.
-    
+
     Parameters:
         refdict: individual-income-tax reform dict for itax.Policy class
         data: investor data for itax.Records class
     """
-    
+
     def __init__(self, refdict=None, data='puf.csv'):
         # Specify refdict
         if refdict is None:
-            self.refdict = {}            
+            self.refdict = {}
         if isinstance(refdict, dict):
             self.refdict = refdict
         else:
@@ -37,17 +41,17 @@ class Investor():
 
     def initiate_calculator(self):
         """
-        Creates an intial version of the taxcalc.Calculator object for 2014
+        Creates an intial version of the itax.Calculator object for START_YEAR
         """
         policy = itax.Policy()
         records = itax.Records(data=self.records_data)
         if self.refdict != {}:
             policy.implement_reform(self.refdict)
-        calc = itax.Calculator( policy=policy, records=records, verbose=False)
-        calc.advance_to_year(2014)
+        calc = itax.Calculator(policy=policy, records=records, verbose=False)
+        calc.advance_to_year(START_YEAR)
         calc.calc_all()
         return calc
-    
+
     def calc_tauNC(self, mtrdict, incdict):
         """
         Calculate the effective marginal tax rate on noncorporate business income.
@@ -70,8 +74,7 @@ class Investor():
         mtr_td = sum(mtr4 * inc4 * posti * wgt) / sum(inc4 * posti * wgt)
         mtr_nc = alpha_nc_ft * mtr_ft + alpha_nc_td * mtr_td
         return mtr_nc
-    
-    
+
     def calc_tauE(self, mtrdict, incdict, year):
         """
         Calculate the effective marginal tax rate on equity income in year.
@@ -79,7 +82,9 @@ class Investor():
         # Retained earnings rate
         m = 0.44
         # Nominal expected return to equity
-        E = Data().econ_defaults['r_e_c'][year-2014] + Data().econ_defaults['pi'][year-2014]
+        iyr = year - START_YEAR
+        E = (Data().econ_defaults['r_e_c'][iyr]
+             + Data().econ_defaults['pi'][iyr])
         # shares of cg in short-term, long-term, and held until death
         omega_scg = 0.034
         omega_lcg = 0.496
@@ -114,26 +119,28 @@ class Investor():
         # accrual effective mtr on ltcg
         tau_lcg1 = (sum(mtr_lcg * inc_lcg * posti * wgt) /
                     sum(inc_lcg * posti * wgt))
-        tau_lcg = 1 - (np.log(np.exp(m * E * h_lcg) * (1 - tau_lcg1) + tau_lcg1) /
-                       (m * E * h_lcg))
+        tau_lcg = 1 - (np.log(np.exp(m * E * h_lcg)
+                              * (1 - tau_lcg1) + tau_lcg1) / (m * E * h_lcg))
         # mtr on capital gains held until death
         tau_xcg = 0.0
-        tau_cg = omega_scg * tau_scg + omega_lcg * tau_lcg + omega_xcg * tau_xcg
+        tau_cg = (omega_scg * tau_scg
+                  + omega_lcg * tau_lcg
+                  + omega_xcg * tau_xcg)
         tau_ft = (1 - m) * tau_d + m * tau_cg
-        tau_td1 = sum(mtr_td * inc_td * posti * wgt) / sum(inc_td * posti * wgt)
+        tau_td1 = (sum(mtr_td * inc_td * posti * wgt)
+                   / sum(inc_td * posti * wgt))
         tau_td = 1 - (np.log(np.exp(E * h_td) * (1 - tau_td1) + tau_td1) /
                       (E * h_td))
         tau_e = alpha_ft * tau_ft + alpha_td * tau_td + alpha_nt * 0.0
-        return(tau_e)
-    
-    
+        return tau_e
+
     def gen_mtr_lists(self):
         # Calculate the EMTR on income from corporate equity
         # and non-corporate business.
-        mtrlist_nc = np.zeros(14)
-        mtrlist_e = np.zeros(14)
+        mtrlist_nc = np.zeros(NUM_YEARS)
+        mtrlist_e = np.zeros(NUM_YEARS)
         calc1 = self.initiate_calculator()
-        for year in range(2014, 2028):
+        for year in range(START_YEAR, END_YEAR + 1):
             calc1.advance_to_year(year)
             calc1.calc_all()
             # Get individual MTRs on each income type
@@ -152,103 +159,104 @@ class Investor():
             inc1['wgt'] = calc1.array('s006')
             inc1['taxinc'] = calc1.array('c04800')
             # Calculate and save overall MTRs
-            mtrlist_nc[year-2014] = self.calc_tauNC(mtr1, inc1)
-            mtrlist_e[year-2014] = self.calc_tauE(mtr1, inc1, year)
+            iyr = year - START_YEAR
+            mtrlist_nc[iyr] = self.calc_tauNC(mtr1, inc1)
+            mtrlist_e[iyr] = self.calc_tauE(mtr1, inc1, year)
         self.mtrlist_nc = mtrlist_nc
         self.mtrlist_e = mtrlist_e
-    
+
     def get_tauNClist(self):
         """
         Returns mtrlist_nc as an array
         """
         return np.array(self.mtrlist_nc)
-    
+
     def get_tauElist(self):
         """
         Returns mtrlist_e as an array
         """
         return np.array(self.mtrlist_e)
-    
+
     def distribute_results(self, multipliers):
         """
-        Pass effects of business tax reform to taxcalc.
+        Pass effects of business tax reform to itax.
         Adjusts individual income based on growth factors.
         Adjusts noncorporate business credits based on rescaling factors from
         legal shifting response.
         """
         calc1 = self.initiate_calculator()
-        indiv_revenue = np.zeros(14)
-        for i in range(2014, 2028):
+        indiv_revenue = np.zeros(NUM_YEARS)
+        for iyr in range(0, NUM_YEARS):
+            year = iyr + START_YEAR
             calc2 = copy.deepcopy(calc1)
             # Change Sch C business income
             ref2_e00900p = calc2.array('e00900p')
             ref2_e00900s = calc2.array('e00900s')
             ref2_e00900 = calc2.array('e00900')
             ref3_e00900p = np.where(ref2_e00900p >= 0,
-                                    ref2_e00900p * multipliers['SchC_pos'][i-2014],
-                                    ref2_e00900p * multipliers['SchC_neg'][i-2014])
+                                    ref2_e00900p * multipliers['SchC_pos'][iyr],
+                                    ref2_e00900p * multipliers['SchC_neg'][iyr])
             ref3_e00900s = np.where(ref2_e00900s >= 0,
-                                    ref2_e00900s * multipliers['SchC_pos'][i-2014],
-                                    ref2_e00900s * multipliers['SchC_neg'][i-2014])
+                                    ref2_e00900s * multipliers['SchC_pos'][iyr],
+                                    ref2_e00900s * multipliers['SchC_neg'][iyr])
             ref3_e00900 = np.where(ref2_e00900 >= 0,
-                                   ref2_e00900 * multipliers['SchC_pos'][i-2014],
-                                   ref2_e00900 * multipliers['SchC_neg'][i-2014])
+                                   ref2_e00900 * multipliers['SchC_pos'][iyr],
+                                   ref2_e00900 * multipliers['SchC_neg'][iyr])
             calc2.array('e00900p', ref3_e00900p)
             calc2.array('e00900s', ref3_e00900s)
             calc2.array('e00900', ref3_e00900)
             # Change Sch E business income
             ref2_e26270 = calc2.array('e26270')
             change_e26270 = np.where(ref2_e26270 >= 0,
-                                     ref2_e26270 * (multipliers['e26270_pos'][i-2014] - 1),
-                                     ref2_e26270 * (multipliers['e26270_neg'][i-2014] - 1))
+                                     ref2_e26270 * (multipliers['e26270_pos'][iyr] - 1),
+                                     ref2_e26270 * (multipliers['e26270_neg'][iyr] - 1))
             ref3_e26270 = ref2_e26270 + change_e26270
             ref3_e02000 = calc2.array('e02000') + change_e26270
             calc2.array('e26270', ref3_e26270)
             calc2.array('e02000', ref3_e02000)
             # Change investment income
-            calc2.array('e00600', calc2.array('e00600') * multipliers['equity'][i-2014])
-            calc2.array('e00650', calc2.array('e00650') * multipliers['equity'][i-2014])
-            calc2.array('p22250', calc2.array('p22250') * multipliers['equity'][i-2014])
-            calc2.array('p23250', calc2.array('p23250') * multipliers['equity'][i-2014])
+            calc2.array('e00600', calc2.array('e00600') * multipliers['equity'][iyr])
+            calc2.array('e00650', calc2.array('e00650') * multipliers['equity'][iyr])
+            calc2.array('p22250', calc2.array('p22250') * multipliers['equity'][iyr])
+            calc2.array('p23250', calc2.array('p23250') * multipliers['equity'][iyr])
             # Change noncorporate business credits
-            calc2.array('e07300', calc2.array('e07300') * multipliers['rescale_noncorp'][i-2014])
-            calc2.array('e07400', calc2.array('e07400') * multipliers['rescale_noncorp'][i-2014])
-            calc2.array('e07600', calc2.array('e07600') * multipliers['rescale_noncorp'][i-2014])
+            calc2.array('e07300', calc2.array('e07300') * multipliers['rescale_noncorp'][iyr])
+            calc2.array('e07400', calc2.array('e07400') * multipliers['rescale_noncorp'][iyr])
+            calc2.array('e07600', calc2.array('e07600') * multipliers['rescale_noncorp'][iyr])
             calc2.calc_all()
             # Calculate total individual income and payroll tax revenue
-            indiv_revenue[i-2014] = sum(calc2.array('combined') * calc2.array('s006')) / 10**9
+            indiv_revenue[iyr] = calc2.weighted_total('combined') * 1e-9
             # Advance calc1 to the next year and recalculate
-            if i < 2027:
+            if year < END_YEAR:
                 calc1.increment_year()
                 calc1.calc_all()
         self.revenue_postdistribution = indiv_revenue
-    
+
     def undistributed_revenue(self):
         """
-        Calculates individual income tax revenue for each year without 
-        distributing any tax changes. 
+        Calculates individual income tax revenue for each year without
+        distributing any tax changes.
         """
         calc1 = self.initiate_calculator()
-        indiv_revenue = np.zeros(14)
-        for i in range(2014, 2028):
-            indiv_revenue[i-2014] = sum(calc1.array('combined') * calc1.array('s006')) / 10**9
-            if i < 2027:
+        indiv_revenue = np.zeros(NUM_YEARS)
+        for iyr in range(0, NUM_YEARS):
+            year = iyr + START_YEAR
+            indiv_revenue[iyr] = calc1.weighted_total('combined') * 1e-9
+            if year < END_YEAR:
                 calc1.increment_year()
                 calc1.calc_all()
         self.revenue_predistribution = indiv_revenue
-    
+
     def get_revenue_withdistribution(self):
         """
-        Returns total individual income tax revenue after corporate tax 
+        Returns total individual income tax revenue after corporate tax
         distribution and noncorporate business income distribution.
         """
         return np.array(self.revenue_postdistribution)
-    
+
     def get_revenue_nodistribution(self):
         """
         Returns total individual income tax revenue with no business income
         distribution.
         """
         return np.array(self.revenue_predistribution)
-    
-    

--- a/biztax/passthrough.py
+++ b/biztax/passthrough.py
@@ -1,3 +1,6 @@
+"""
+Business-Taxation PassThrough class.
+"""
 import copy
 import numpy as np
 import pandas as pd
@@ -11,10 +14,10 @@ from biztax.response import Response
 class PassThrough():
     """
     Constructor for the PassThrough class.
-    
+
     This contains the calculation of pass-through business income. All other
     components of pass-through taxation occur through Tax-Calculator.
-    
+
     For now, a PassThrough object contains 6 different business entities:
         sole proprietorship, positive net income
         sole proprietorship, negative net income
@@ -22,20 +25,20 @@ class PassThrough():
         S corporation, negative net income
         partnership, positive net income
         partnership, negative net income
-    Therefore, the process for modeling the pass-through sector evolves in 
+    Therefore, the process for modeling the pass-through sector evolves in
     two stages. The first, like for the Corporation class, produces a single
     Asset object, Debt object and earnings for the pass-through sector. Once
     these are calculated, they are split between each of the 6 entities. The
     results from these will later be used by the Investor class to distribute
-    the changes in business income to individuals in Tax-Calculator. 
-    
+    the changes in business income to individuals in Tax-Calculator.
+
     The following functions apply to the sector as a whole:
         create_asset()
         create_earnings()
         create_debt()
-       real_activity() 
+        real_activity()
     """
-    
+
     def __init__(self, btax_params):
         # Store policy parameter objects
         if isinstance(btax_params, pd.DataFrame):
@@ -49,7 +52,7 @@ class PassThrough():
         self.asset.calc_all()
         # Create earnings forecast
         self.create_earnings()
-    
+
     def create_earnings(self):
         """
         Creates the initial forecast for earnings. Static only.
@@ -73,25 +76,26 @@ class PassThrough():
         # Aggregate and save EBITDAs
         total_inc = (sp_posinc + sp_neginc + part_posinc + part_neginc +
                      scorp_posinc + scorp_neginc)
-        earnings_result = pd.DataFrame({'year': range(2014,2028),
+        earnings_result = pd.DataFrame({'year': range(START_YEAR,
+                                                      END_YEAR + 1),
                                         'total': total_inc,
                                         'SchC_pos': sp_posinc,
                                         'SchC_neg': sp_neginc,
                                         'partner_pos': part_posinc,
                                         'partner_neg': part_neginc,
-                                        'Scorp_pos': scorp_posinc, 
+                                        'Scorp_pos': scorp_posinc,
                                         'Scorp_neg': scorp_neginc})
         self.earnings = earnings_result
-    
+
     def create_debt(self):
         """
-        Creates the Debt object for the pass-through sector. 
+        Creates the Debt object for the pass-through sector.
         Note: create_asset must have already been called
         """
         self.debt = Debt(self.btax_params, self.asset.get_forecast(),
                          data=self.data, corp=False)
         self.debt.calc_all()
-    
+
     def real_activity(self):
         """
         Produces a DataFrame of the pass-through sector's real activity.
@@ -106,9 +110,9 @@ class PassThrough():
             Cash flow
         Note that unlike for a corporation, the final real activity measures
         (net income and cash flow) are pre-tax, as these would be passed to
-        units in Tax-Calculator. 
+        units in Tax-Calculator.
         """
-        real_results = pd.DataFrame({'year': range(2014,2028),
+        real_results = pd.DataFrame({'year': range(START_YEAR, END_YEAR + 1),
                                      'Earnings': self.earnings['total']})
         real_results['Kstock'] = self.asset.get_forecast()
         real_results['Inv'] = self.asset.get_investment()
@@ -118,12 +122,12 @@ class PassThrough():
         real_results['NetInc'] = real_results['Earnings'] - real_results['Depr'] - real_results['NIP']
         real_results['CashFlow'] = real_results['Earnings'] - real_results['Inv']
         self.real_results = real_results
-    
+
     def calc_schC(self):
         """
         Calculates net income for sole proprietorships
         """
-        SchC_results = pd.DataFrame({'year': range(2014,2028)})
+        SchC_results = pd.DataFrame({'year': range(START_YEAR, END_YEAR + 1)})
         # Update earnings
         SchC_results['ebitda_pos'] = self.earnings['SchC_pos']
         SchC_results['ebitda_neg'] = self.earnings['SchC_neg']
@@ -137,12 +141,13 @@ class PassThrough():
         SchC_results['netinc_pos'] = SchC_results['ebitda_pos'] - SchC_results['dep_pos'] - SchC_results['intded_pos']
         SchC_results['netinc_neg'] = SchC_results['ebitda_neg'] - SchC_results['dep_neg'] - SchC_results['intded_neg']
         self.SchC_results = SchC_results
-    
+
     def calc_partner(self):
         """
         Calculates net income for partnerships
         """
-        partner_results = pd.DataFrame({'year': range(2014,2028)})
+        partner_results = pd.DataFrame({'year': range(START_YEAR,
+                                                      END_YEAR + 1)})
         # Update earnings
         partner_results['ebitda_pos'] = self.earnings['partner_pos']
         partner_results['ebitda_neg'] = self.earnings['partner_neg']
@@ -156,12 +161,12 @@ class PassThrough():
         partner_results['netinc_pos'] = partner_results['ebitda_pos'] - partner_results['dep_pos'] - partner_results['intded_pos']
         partner_results['netinc_neg'] = partner_results['ebitda_neg'] - partner_results['dep_neg'] - partner_results['intded_neg']
         self.partner_results = partner_results
-    
+
     def calc_Scorp(self):
         """
         Calculates net income for S corporations
         """
-        Scorp_results = pd.DataFrame({'year': range(2014,2028)})
+        Scorp_results = pd.DataFrame({'year': range(START_YEAR, END_YEAR + 1)})
         # Update earnings
         Scorp_results['ebitda_pos'] = self.earnings['Scorp_pos']
         Scorp_results['ebitda_neg'] = self.earnings['Scorp_neg']
@@ -175,7 +180,7 @@ class PassThrough():
         Scorp_results['netinc_pos'] = Scorp_results['ebitda_pos'] - Scorp_results['dep_pos'] - Scorp_results['intded_pos']
         Scorp_results['netinc_neg'] = Scorp_results['ebitda_neg'] - Scorp_results['dep_neg'] - Scorp_results['intded_neg']
         self.Scorp_results = Scorp_results
-    
+
     def calc_netinc(self):
         """
         Runs all calculations for each entity and saves the net income results.
@@ -183,7 +188,8 @@ class PassThrough():
         self.calc_schC()
         self.calc_partner()
         self.calc_Scorp()
-        netinc_results = pd.DataFrame({'year': range(2014,2028)})
+        netinc_results = pd.DataFrame({'year': range(START_YEAR,
+                                                     END_YEAR + 1)})
         netinc_results['SchC_pos'] = self.SchC_results['netinc_pos']
         netinc_results['SchC_neg'] = self.SchC_results['netinc_neg']
         netinc_results['partner_pos'] = self.SchC_results['netinc_pos']
@@ -191,7 +197,7 @@ class PassThrough():
         netinc_results['Scorp_pos'] = self.SchC_results['netinc_pos']
         netinc_results['Scorp_neg'] = self.SchC_results['netinc_neg']
         self.netinc_results = netinc_results
-    
+
     def calc_static(self):
         """
         Runs the static calculations
@@ -199,15 +205,17 @@ class PassThrough():
         self.create_debt()
         self.real_activity()
         self.calc_netinc()
-    
+
     def update_legal(self, responses):
         """
         Updates the rescale_corp and rescale_noncorp associated with each
         Data associated with each object.
         """
-        self.data.update_rescaling(responses.rescale_corp, responses.rescale_noncorp)
-        self.asset.data.update_rescaling(responses.rescale_corp, responses.rescale_noncorp)
-    
+        self.data.update_rescaling(responses.rescale_corp,
+                                   responses.rescale_noncorp)
+        self.asset.data.update_rescaling(responses.rescale_corp,
+                                         responses.rescale_noncorp)
+
     def update_investment(self, responses):
         """
         Updates the Asset object to include investment response.
@@ -216,7 +224,7 @@ class PassThrough():
         self.old_capital_history = copy.deepcopy(self.asset.capital_history)
         self.asset.update_response(responses.investment_response)
         self.asset.calc_all()
-    
+
     def update_earnings(self, responses):
         """
         Recalculates earnings using the old capital stock by asset type, the
@@ -226,21 +234,24 @@ class PassThrough():
         Kstock_base = copy.deepcopy(self.old_capital_history)
         Kstock_ref = copy.deepcopy(self.asset.capital_history)
         deltaK = Kstock_ref - Kstock_base
-        changeEarnings = np.zeros((96, 14))
-        
-        for j in range(14): # for each year
-            mpk = np.array(responses.investment_response['MPKnc' + str(j + 2014)])
-            for i in range(96): # by asset
-                changeEarnings[i,j] = deltaK[i,j] * mpk[i] * self.data.adjfactor_dep_noncorp
-        deltaE = np.zeros(14)
-        for j in range(14):
+        changeEarnings = np.zeros((96, NUM_YEARS))
+        for j in range(NUM_YEARS):  # for each year
+            ystr = str(j + START_YEAR)
+            mpk = np.array(responses.investment_response['MPKnc' + ystr])
+            for i in range(96):  # by asset
+                changeEarnings[i, j] = (deltaK[i, j] * mpk[i]
+                                        * self.data.adjfactor_dep_noncorp)
+        deltaE = np.zeros(NUM_YEARS)
+        for j in range(NUM_YEARS):  # for each year
             deltaE[j] = changeEarnings[:, j].sum()
         earnings_old = np.array(self.earnings['total'])
-        ebitda_chgfactor = (earnings_old + deltaE) * self.data.rescale_noncorp / earnings_old
+        ebitda_chgfactor = ((earnings_old + deltaE)
+                            * self.data.rescale_noncorp
+                            / earnings_old)
         keylist = list(self.earnings)
         for key in keylist:
             self.earnings[key] = self.earnings[key] * ebitda_chgfactor
-    
+
     def update_debt(self, responses):
         """
         Replaces the Debt object to use the new asset forecast and Data
@@ -249,11 +260,10 @@ class PassThrough():
         self.debt = Debt(self.btax_params, self.asset.get_forecast(),
                          data=self.data, response=pctch_delta, corp=False)
         self.debt.calc_all()
-    
+
     def apply_responses(self, responses):
         """
-        Updates Data, Asset, earnings, and Debt to include 
-        responses.
+        Updates Data, Asset, earnings, and Debt to include responses
         """
         assert isinstance(responses, Response)
         self.update_legal(responses)
@@ -262,5 +272,3 @@ class PassThrough():
         self.update_debt(responses)
         self.real_activity()
         self.calc_netinc()
-    
-    

--- a/biztax/passthrough.py
+++ b/biztax/passthrough.py
@@ -1,6 +1,7 @@
+import copy
 import numpy as np
 import pandas as pd
-import copy
+from biztax.years import START_YEAR, END_YEAR, NUM_YEARS
 from biztax.data import Data
 from biztax.asset import Asset
 from biztax.debt import Debt

--- a/biztax/response.py
+++ b/biztax/response.py
@@ -84,7 +84,8 @@ class Response():
         assert self.elasticities['debt_taxshield_c'] >= 0.0
         assert self.elasticities['debt_taxshield_nc'] >= 0.0
         assert self.elasticities['legalform_ratediff'] <= 0.0
-        assert self.elasticities['first_year_response'] in range(2014, 2028)
+        assert (self.elasticities['first_year_response']
+                in range(START_YEAR, END_YEAR + 1))
 
     def calc_all(self, btax_params_base, btax_params_ref):
         """
@@ -114,25 +115,28 @@ class Response():
         mne_share_c = self.elasticities['mne_share_c']
         mne_share_nc = self.elasticities['mne_share_nc']
         # No responses for years before first_year_response
-        for year in range(2014, firstyear):
-            maindata['deltaIc' + str(year)] = 0.
-            maindata['deltaInc' + str(year)] = 0.
-            maindata['MPKc' + str(year)] = 0.
-            maindata['MPKnc' + str(year)] = 0.
+        for year in range(START_YEAR, firstyear):
+            ystr = str(year)
+            maindata['deltaIc' + ystr] = 0.
+            maindata['deltaInc' + ystr] = 0.
+            maindata['MPKc' + ystr] = 0.
+            maindata['MPKnc' + ystr] = 0.
         # Calculate cost of capital and EATR for every year for baseline
         btaxmini_base = BtaxMini(btax_params_base)
-        results_base = btaxmini_base.run_btax_mini(range(firstyear, 2028))
+        years = range(firstyear, END_YEAR + 1)
+        results_base = btaxmini_base.run_btax_mini(years)
         # Calculate cost of capital and EATR for every year for reform
         btaxmini_ref = BtaxMini(btax_params_ref)
-        results_ref = btaxmini_ref.run_btax_mini(range(firstyear, 2028))
+        results_ref = btaxmini_ref.run_btax_mini(years)
         # Compare results to produce the responses
-        for year in range(firstyear, 2028):
-            maindata['deltaIc' + str(year)] = ((results_ref['u_c' + str(year)] / results_base['u_c' + str(year)] - 1) * elast_c +
-                                               (results_ref['eatr_c' + str(year)] - results_base['eatr_c' + str(year)]) * selast_c * mne_share_c)
-            maindata['deltaInc' + str(year)] = ((results_ref['u_nc' + str(year)] / results_base['u_nc' + str(year)] - 1) * elast_nc +
-                                                (results_ref['eatr_nc' + str(year)] - results_base['eatr_nc' + str(year)]) * selast_nc * mne_share_nc)
-            maindata['MPKc' + str(year)] = (results_ref['u_c' + str(year)] + results_base['u_c' + str(year)]) / 2.0
-            maindata['MPKnc' + str(year)] = (results_ref['u_nc' + str(year)] + results_base['u_nc' + str(year)]) / 2.0
+        for year in years:
+            ystr = str(year)
+            maindata['deltaIc' + ystr] = (((results_ref['u_c' + ystr] / results_base['u_c' + ystr] - 1) * elast_c +
+                                           (results_ref['eatr_c' + ystr] - results_base['eatr_c' + ystr]) * selast_c * mne_share_c))
+            maindata['deltaInc' + ystr] = (((results_ref['u_nc' + ystr] / results_base['u_nc' + ystr] - 1) * elast_nc +
+                                            (results_ref['eatr_nc' + ystr] - results_base['eatr_nc' + ystr]) * selast_nc * mne_share_nc))
+            maindata['MPKc' + ystr] = (results_ref['u_c' + ystr] + results_base['u_c' + ystr]) / 2.0
+            maindata['MPKnc' + ystr] = (results_ref['u_nc' + ystr] + results_base['u_nc' + ystr]) / 2.0
         # Save the responses
         self.investment_response = copy.deepcopy(maindata)
 
@@ -144,11 +148,11 @@ class Response():
         nid_hcs = np.array(btax_params_ref['netIntPaid_corp_hc'])
         id_hc_years = np.array(btax_params_ref['newIntPaid_corp_hcyear'])
         id_hc_new = np.array(btax_params_ref['newIntPaid_corp_hc'])
-        yearlist = np.array(range(2014, 2028))
-        id_hcs = np.where(id_hc_years >= yearlist, id_hc_new, 0.0)
+        years = np.array(range(START_YEAR, END_YEAR + 1))
+        id_hcs = np.where(id_hc_years >= years, id_hc_new, 0.0)
         hclist = np.maximum(nid_hcs, id_hcs)
         elast_debt_list = np.where(
-            yearlist >= self.elasticities['first_year_response'],
+            years >= self.elasticities['first_year_response'],
             self.elasticities['debt_taxshield_c'], 0.0
         )
         taxshield_base = btax_params_base['tau_c']
@@ -163,10 +167,10 @@ class Response():
         # Extract information on haircuts
         id_hc_years = np.array(btax_params_ref['newIntPaid_noncorp_hcyear'])
         id_hc_new = np.array(btax_params_ref['newIntPaid_noncorp_hc'])
-        yearlist = np.array(range(2014, 2028))
-        hclist = np.where(id_hc_years >= yearlist, id_hc_new, 0.0)
+        years = np.array(range(START_YEAR, END_YEAR + 1))
+        hclist = np.where(id_hc_years >= years, id_hc_new, 0.0)
         elast_debt_list = np.where(
-            yearlist >= self.elasticities['first_year_response'],
+            years >= self.elasticities['first_year_response'],
             self.elasticities['debt_taxshield_nc'], 0.0
         )
         taxshield_base = btax_params_base['tau_nc']
@@ -183,7 +187,7 @@ class Response():
                                                    btax_params_ref)
         debtresp_nc = self._calc_debt_response_noncorp(btax_params_base,
                                                        btax_params_ref)
-        debtresp_df = pd.DataFrame({'year': range(2014, 2028),
+        debtresp_df = pd.DataFrame({'year': range(START_YEAR, END_YEAR + 1),
                                     'pchDelta_corp': debtresp_c,
                                     'pchDelta_noncorp': debtresp_nc})
         self.debt_response = debtresp_df
@@ -194,14 +198,14 @@ class Response():
         sections, achieved by modifying the rescaling factors. For now,
         assuming identical tax bases.
         """
-        self.rescale_corp = np.ones(14)
-        self.rescale_noncorp = np.ones(14)
+        self.rescale_corp = np.ones(NUM_YEARS)
+        self.rescale_noncorp = np.ones(NUM_YEARS)
         """
         elast = self.elasticities['legalform_ratediff']
         firstyear = self.elasticities['first_year_response']
-        elast_list = np.zeros(14)
-        for i in range(14):
-            if i + 2014 >= firstyear:
+        elast_list = np.zeros(NUM_YEARS)
+        for i in range(NUM_YEARS):
+            if i + START_YEAR >= firstyear:
                 elast_list[i] = elast
         tau_nc_base = btax_params_base['tau_nc']
         tau_c_base = btax_params_base['tau_c']

--- a/biztax/response.py
+++ b/biztax/response.py
@@ -4,6 +4,7 @@ Business-Taxation Response class.
 import copy
 import numpy as np
 import pandas as pd
+from biztax.years import START_YEAR, END_YEAR, NUM_YEARS
 from biztax.data import Data
 from biztax.btaxmini import BtaxMini
 

--- a/biztax/tests/test_4package.py
+++ b/biztax/tests/test_4package.py
@@ -1,10 +1,6 @@
 """
 Tests for package existence and dependencies consistency.
 """
-# CODING-STYLE CHECKS:
-# pycodestyle test_4package.py
-# pylint --disable=locally-disabled test_4package.py
-
 import os
 import re
 import subprocess

--- a/biztax/tests/test_asset.py
+++ b/biztax/tests/test_asset.py
@@ -1,13 +1,8 @@
 """
 Test Asset class.
 """
-# CODING-STYLE CHECKS:
-# pycodestyle test_asset.py
-# pylint --disable=locally-disabled test_asset.py
-
 import pandas as pd
 import pytest
-# pylint: disable=import-error
 from biztax import Asset, Response
 
 
@@ -54,6 +49,7 @@ def test_update_response(default_btax_params):
     asset.update_response(response_df)
     assert isinstance(asset.response, pd.DataFrame)
 
+
 @pytest.mark.skip
 def test_build_inv_matrix(default_btax_params):
     """
@@ -66,6 +62,7 @@ def test_build_inv_matrix(default_btax_params):
     asset.get_ccr_data()
     asset.build_inv_matrix()
     assert isinstance(asset.investment_history, pd.DataFrame)
+
 
 @pytest.mark.skip
 def test_calc_depreciation_allyears(puf_subsample, default_btax_params):
@@ -90,6 +87,7 @@ def test_calc_depreciation_allyears(puf_subsample, default_btax_params):
     asset = Asset(default_btax_params,
                   response=bizmod.response.investment_response)
     asset.calcDep_allyears()
+
 
 @pytest.mark.skip
 def test_calc_depreciation_budget(default_btax_params):

--- a/biztax/tests/test_bm_corp.py
+++ b/biztax/tests/test_bm_corp.py
@@ -1,14 +1,9 @@
 """
-Test corpoate-aspects of BusinessModel class.
+Test corporate-aspects of BusinessModel class.
 """
-# CODING-STYLE CHECKS:
-# pycodestyle test_bm_corp.py
-# pylint --disable=locally-disabled test_bm_corp.py
-
 import os
 import filecmp
 import pytest
-# pylint: disable=import-error
 from biztax import BusinessModel, Response
 
 

--- a/biztax/tests/test_btaxmini.py
+++ b/biztax/tests/test_btaxmini.py
@@ -1,13 +1,8 @@
 """
 Test BtaxMini class.
 """
-# CODING-STYLE CHECKS:
-# pycodestyle test_btaxmini.py
-# pylint --disable=locally-disabled test_btaxmini.py
-
 import pandas as pd
 import pytest
-# pylint: disable=import-error
 from biztax import BtaxMini
 
 

--- a/biztax/tests/test_corp.py
+++ b/biztax/tests/test_corp.py
@@ -1,12 +1,7 @@
 """
 Test Corporation class.
 """
-# CODING-STYLE CHECKS:
-# pycodestyle test_corp.py
-# pylint --disable=locally-disabled test_corp.py
-
 import pytest
-# pylint: disable=import-error
 from biztax import Corporation
 
 

--- a/biztax/tests/test_corptaxreturn.py
+++ b/biztax/tests/test_corptaxreturn.py
@@ -1,13 +1,8 @@
 """
 Test CorpTaxReturn class.
 """
-# CODING-STYLE CHECKS:
-# pycodestyle test_corptaxreturn.py
-# pylint --disable=locally-disabled test_corptaxreturn.py
-
 import numpy as np
 import pytest
-# pylint: disable=import-error
 from biztax import CorpTaxReturn, Data, Asset, Debt
 
 

--- a/biztax/tests/test_corptaxreturn.py
+++ b/biztax/tests/test_corptaxreturn.py
@@ -50,4 +50,4 @@ def test_instantiation_and_update_methods(default_btax_params):
     ctr.update_debts(good_debts)
     with pytest.raises(ValueError):
         ctr.update_debts(bad_debts)
-    ctr.update_earnings(good_earnings)        
+    ctr.update_earnings(good_earnings)

--- a/biztax/tests/test_data.py
+++ b/biztax/tests/test_data.py
@@ -1,13 +1,8 @@
 """
 Test Data class.
 """
-# CODING-STYLE CHECKS:
-# pycodestyle test_data.py
-# pylint --disable=locally-disabled test_data.py
-
-import pytest
 import numpy as np
-# pylint: disable=import-error
+import pytest
 from biztax import Data
 
 

--- a/biztax/tests/test_debt.py
+++ b/biztax/tests/test_debt.py
@@ -1,13 +1,8 @@
 """
 Test Debt class.
 """
-# CODING-STYLE CHECKS:
-# pycodestyle test_debt.py
-# pylint --disable=locally-disabled test_debt.py
-
 import numpy as np
 import pytest
-# pylint: disable=import-error
 from biztax import Debt, Asset, Data
 
 

--- a/biztax/tests/test_debt.py
+++ b/biztax/tests/test_debt.py
@@ -68,9 +68,9 @@ def test_constrain_history(default_btax_params):
     """
     good_asset_forecast = np.ones(14)
     debt = Debt(default_btax_params, good_asset_forecast)
-    debt.get_haircuts() 
-    debt.build_level_history() 
-    debt.build_flow_history() 
+    debt.get_haircuts()
+    debt.build_level_history()
+    debt.build_flow_history()
     debt.originations[0] = -9.9  # triggers constrain_history logic
-    debt.constrain_history() 
+    debt.constrain_history()
     assert min(debt.originations) == 0.0

--- a/biztax/tests/test_pthru.py
+++ b/biztax/tests/test_pthru.py
@@ -1,12 +1,7 @@
 """
 Test PassThrough class.
 """
-# CODING-STYLE CHECKS:
-# pycodestyle test_pthru.py
-# pylint --disable=locally-disabled test_pthru.py
-
 import pytest
-# pylint: disable=import-error
 from biztax import PassThrough
 
 

--- a/biztax/tests/test_response.py
+++ b/biztax/tests/test_response.py
@@ -27,5 +27,3 @@ def test_update_elasticities():
     with pytest.raises(ValueError):
         response.update_elasticities({'unknown_elasticity_name': 0.0})
     response.update_elasticities({'inv_eatr_c': -0.8})
-
-    

--- a/biztax/tests/test_response.py
+++ b/biztax/tests/test_response.py
@@ -1,13 +1,8 @@
 """
 Test Response class.
 """
-# CODING-STYLE CHECKS:
-# pycodestyle test_response.py
-# pylint --disable=locally-disabled test_response.py
-
 import numpy as np
 import pytest
-# pylint: disable=import-error
 from biztax import Response
 
 

--- a/biztax/tests/test_years.py
+++ b/biztax/tests/test_years.py
@@ -1,0 +1,14 @@
+"""
+Test named numerical constants in the years.py file.
+"""
+import taxcalc as itax
+from biztax import START_YEAR, END_YEAR
+
+
+def test_years():
+    """
+    Test that years-related constants are compatible with itax.Policy years
+    """
+    assert START_YEAR <= END_YEAR
+    assert START_YEAR >= itax.Policy.JSON_START_YEAR
+    assert END_YEAR <= itax.Policy.LAST_BUDGET_YEAR

--- a/biztax/years.py
+++ b/biztax/years.py
@@ -1,0 +1,9 @@
+"""
+Business-Taxation years-related named numerical constants.
+"""
+
+START_YEAR = 2014
+
+END_YEAR = 2027
+
+NUM_YEARS = END_YEAR - START_YEAR + 1


### PR DESCRIPTION
This pull request adds a `years.py` file (and imports it into the other modules) so that the [magic numbers](https://en.wikipedia.org/wiki/Magic_number_(programming)) `2014`, `2027`, `2028`, and `14` can be replaced with named constants.  This makes the code easier to read and, more importantly, easier to maintain because the last simulation year will be increased in the future.  Using these named constants is also essential for developing a Business-Taxation Policy class.

So, all these changes are cosmetic in the sense that there is no change in Business-Taxation logic.  This means that the pytest results and the results generated by the `example.py` script are unchanged.

Since using the named constants required cosmetic editing of each `biztax/*py` file, it seemed sensible to also begin bringing the code closer to being in compliance with the `PEP8` coding style (which focuses mostly on the vertical and horizontal placement of code elements).  Eventually, this coding-style test will be part of the GitHub check-in testing (along with running the `pytest` suite and code-coverage calculations).  The code in this pull request generates these coding-style errors:
```
iMac:Business-Taxation mrh$ pycodestyle biztax | grep -v E501 | grep -v preTCJA
biztax/btaxmini.py:114:13: E741 ambiguous variable name 'I'
biztax/btaxmini.py:116:13: E741 ambiguous variable name 'I'
biztax/debt.py:128:9: E741 ambiguous variable name 'O'
biztax/debt.py:148:13: E741 ambiguous variable name 'O'
iMac:Business-Taxation mrh$ 
```
The `grep` statements weed out the E501 errors (lines longer than 79 characters) and weed out spacing errors in the `biztax/brcparams_preTCJA.json` and `biztax/brcparams_preTCJA_special.json` files, which appear to be unused in the Business-Taxation code.

@codykallen,  I'm not planning any additional changes to this pull request unless you identify needed changes.
