### PR TITLE
Add repatriation response

### DIFF
--- a/biztax/cfc.py
+++ b/biztax/cfc.py
@@ -88,14 +88,16 @@ class CFC():
         """
         assert isinstance(update_df, pd.DataFrame)
         assert len(update_df) == 14
+        reprate_e = np.asarray(self.cfc_data['reprate_e'])
         if 'reprate_e' in update_df:
             # Update repatriation rate on current earnings
-            self.cfc_data['reprate_e'] = update_df['reprate_e']
-        if 'reprate_e' in update_df:
-            # Update repatriation rate on accumulated profits
-            self.cfc_data['reprate_e'] = update_df['reprate_e']
-        # Recalculate using new repatriation decisions
-        self.repatriate_accumulate()
+            reprate_e[1:] = np.minimum(np.maximum(reprate_e[1:] +
+                                                  update_df['reprate_e'], 0), 1.)
+            self.cfc_data['reprate_e'] = reprate_e
+        if 'reprate_a' in update_df:
+            # Update repatriation rate on accumulated profits (if built)
+            self.cfc_data['reprate_e'] = self.cfc_data['reprate_e']
+
 
 
 

--- a/biztax/corporation.py
+++ b/biztax/corporation.py
@@ -125,6 +125,15 @@ class Corporation():
         self.asset.update_response(responses.investment_response)
         self.asset.calc_all()
 
+    def update_repatriation(self, responses):
+        """
+        Updates the DomesticMNE object to include the repatriation response.
+        Also updates profits to reflect this response.
+        """
+        # First, save current foreign earnings
+        self.dmne.update_profits(responses.repatriation_response)
+        self.dmne.calc_all()
+
     def update_earnings(self, responses):
         """
         Recalculates earnings using the old capital stock by asset type, the
@@ -144,7 +153,9 @@ class Corporation():
         deltaE = np.zeros(NUM_YEARS)
         for iyr in range(NUM_YEARS):
             deltaE[iyr] = changeEarnings[:, iyr].sum()
-        self.earnings = (self.earnings + deltaE) * self.data.rescale_corp
+        # Update new earnings
+        self.dearnings = (self.dearnings + deltaE) * self.data.rescale_corp
+        self.earnings = self.dearnings + self.dmne.dmne_results['foreign_inc']
 
     def update_debt(self, responses):
         """
@@ -163,6 +174,7 @@ class Corporation():
         assert isinstance(responses, Response)
         self.update_legal(responses)
         self.update_investment(responses)
+        self.update_repatriation(responses)
         self.update_earnings(responses)
         self.update_debt(responses)
         self.file_taxes()

--- a/biztax/domesticmne.py
+++ b/biztax/domesticmne.py
@@ -127,11 +127,10 @@ class DomesticMNE():
         """
         return None
     
-    def update_profits(self):
+    def update_profits(self, repat_response):
         """
         Updates location of profits based on profit-shifting response and
-        change in capital location from investment response.
-        Include response by CFC.
-        Not yet built.
+        repatriation rate from profits in CFC.
+        Currently, only handles the repatriation response.
         """
-        return None
+        self.cfc.update_cfc(repat_response)


### PR DESCRIPTION
This PR adds the repatriation response for CFCs. This does not change any results unless a repatriation semi-elasticity is used.

The repatriation response only applies to repatriations from current profits from CFCs. Repatriations out of accumulated profits cannot be so easily modeled, and with the 2017 tax act will become irrelevant.