### PR TITLE
Add pytest.ini file

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+testpaths =
+    biztax
+markers =
+    requires_pufcsv
+    local
+    pep8


### PR DESCRIPTION
This PR adds a `pytest.ini1 file with the relevant marks. This resolves #97. 