### PR TITLE
Profit shifting response

### DIFF
--- a/biztax/cfc.py
+++ b/biztax/cfc.py
@@ -103,15 +103,19 @@ class CFC():
         """
         self.pay_foreign_taxes()
         self.repatriate_accumulate()
+        # Add certain results to policy DataFrame
+        self.btax_params['ftaxrate'] = self.ftaxrate
+        self.btax_params['reprate_e'] = self.reprate_earnings
 
-    def update_cfc(self, update_df):
+    def update_cfc(self, update_df, shift_response=None):
         """
         Updates the forecast for the repatriation rates.
         Then calls calc_all() using the new repatriation decisions.
 
         update_df should be a DataFrame object with columns
         [year, reprate_e, reprate_a]
-        and years 2014:2028
+        shift_response is array of income shifted between
+        nondeferred foreign source and CFC
         """
         assert isinstance(update_df, pd.DataFrame)
         assert len(update_df) == NUM_YEARS
@@ -123,3 +127,6 @@ class CFC():
         if 'reprate_a' in update_df:
             # Update repatriation rate on accumulated profits (if built)
             self.reprate_accum = self.reprate_accum + update_df['reprate_a']
+        if shift_response is not None:
+            # Update earnings
+            self.earnings = self.earnings + shift_response

--- a/biztax/corporation.py
+++ b/biztax/corporation.py
@@ -200,7 +200,8 @@ class Corporation():
         Also updates profits to reflect this response.
         """
         # First, save current foreign earnings
-        self.dmne.update_profits(responses.repatriation_response)
+        self.dmne.update_profits(responses.repatriation_response,
+                                 responses.shifting_response)
         self.dmne.calc_all()
 
     def update_earnings(self, responses):

--- a/demo.py
+++ b/demo.py
@@ -15,7 +15,8 @@ btax_policy_reform0.implement_reform(btax_reform_dict0)
 itax_policy_noreform0 = itax.Policy()
 
 # Execute BusinessModel calculations with no response
-BM0 = BusinessModel(btax_policy_reform0, itax_policy_noreform0, investor_data='rpuf.csv')
+BM0 = BusinessModel(btax_policy_reform0, itax_policy_noreform0,
+                    investor_data='rpuf.csv')
 BM0.calc_all(response=None)
 
 print(BM0.model_results)
@@ -54,7 +55,8 @@ btax_policy_reform1.implement_reform(btax_reform_dict1)
 itax_policy_noreform1 = itax.Policy()
 
 # Execute BusinessModel calculations with no response
-BM1 = BusinessModel(btax_policy_reform1, itax_policy_noreform1, investor_data='rpuf.csv')
+BM1 = BusinessModel(btax_policy_reform1, itax_policy_noreform1,
+                    investor_data='rpuf.csv')
 BM1.calc_all(response=None)
 
 print(BM1.model_results)
@@ -84,7 +86,7 @@ btax_reform_dict2 = {
     'muniIntIncome_corp_hc': {2020: 0.0},
     'adjustedTaxInc_limit': {2020: 9e99},
     'statelocaltax_hc': {2020: 1.0},
-    'pymtc_hc': {2018: 1.0},
+    'pymtc_hc': {2020: 1.0},
     'GILTI_thd': {2020: 0.0},
     'GILTI_inclusion': {2020: 1.0},
     'fdii_rt': {2020: 0.0}
@@ -98,7 +100,8 @@ btax_policy_reform2.implement_reform(btax_reform_dict2)
 itax_policy_noreform2 = itax.Policy()
 
 # Execute BusinessModel calculations with no response
-BM2 = BusinessModel(btax_policy_reform2, itax_policy_noreform2, investor_data='rpuf.csv')
+BM2 = BusinessModel(btax_policy_reform2, itax_policy_noreform2,
+                    investor_data='rpuf.csv')
 BM2.calc_all(response=None)
 
 print(BM2.model_results)


### PR DESCRIPTION
This adds the profit-shifting response, using a semi-elasticity of profits booked in CFCs with respect to the tax shield from booking in CFCs. 

The profit-shifting response has not yet been incorporated into the baseline. For the semi-elasticities to use, see [Dowd, Landefeld and Moore (2017)](https://www.sciencedirect.com/science/article/abs/pii/S004727271730018X). 